### PR TITLE
se eliminan datos sensibles y se creo .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# URI de conexión a MongoDB Atlas
+MONGODB_URI=mongodb+srv://<"user">:<"password">@<"cluster">-cluster.eadxgbn.mongodb.net/talleresdb?retryWrites=true&w=majority
+
+# Clave secreta para firmar los JWT
+JWT_SECRET=mi_secreto_super_seguro

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Se eliminó el archivo .env que contenía credenciales reales de MongoDB.
Se agregó un archivo .env.example con placeholders para un uso seguro.
Se actualizó .gitignore para evitar subir .env.

Impacto
Protege credenciales y previene exposición accidental de datos sensibles.

Cómo probar
1. Clonar el repo
2. Crear un archivo .env propio copiando el contenido de .env.example y llenando valores reales.
3. Iniciar la app normalmente.
